### PR TITLE
WEBDOM-376: Do not persist empty entities.

### DIFF
--- a/FieldType/AbstractCapistranoFieldType.php
+++ b/FieldType/AbstractCapistranoFieldType.php
@@ -44,8 +44,10 @@ abstract class AbstractCapistranoFieldType extends AbstractFieldType
         $ids = [];
 
         foreach ($value as $entity) {
-            $this->entityManager->persist($entity);
-            $ids[] = $entity->getId();
+            if ($entity) {
+                $this->entityManager->persist($entity);
+                $ids[] = $entity->getId();
+            }
         }
 
         return json_encode($ids);


### PR DESCRIPTION
I didn't use array_filter because `$value` can be a doctrine collection object as well.